### PR TITLE
Updating resume link on github

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -144,7 +144,7 @@ syntax-highlight: True
 ###########
 
 email: "coffee@thealphadollar.me"
-resume_link: "https://github.com/thealphadollar/my_resume/blob/master/resume_thealphadollar.pdf"
+resume_link: "https://github.com/thealphadollar/my_resume/blob/master/ShivamJha_IITKgp.pdf"
 
 ################
 # Author Blurb #


### PR DESCRIPTION
Referring to this particular commit of [changing name of resume file](https://github.com/thealphadollar/my_resume/commit/09a771ced9cde9d744890555331cd34151da7638), was not updated on the website.. that's all what this PR is all about.. just updating it